### PR TITLE
Fix scripted paradrops

### DIFF
--- a/mods/ra/maps/allies-03a/allies03a.lua
+++ b/mods/ra/maps/allies-03a/allies03a.lua
@@ -16,7 +16,13 @@ else
 	ChangeStance = true
 end
 
-IdleHunt = function(actor) Trigger.OnIdle(actor, actor.Hunt) end
+IdleHunt = function(actor)
+	Trigger.OnIdle(actor, function(a)
+		if a.IsInWorld then
+			a.Hunt()
+		end
+	end)
+end
 
 ProduceUnits = function(factory, count)
 	if ussr.IsProducing("e1") then

--- a/mods/ra/maps/allies-03b/allies03b.lua
+++ b/mods/ra/maps/allies-03b/allies03b.lua
@@ -27,7 +27,13 @@ else
 	ChangeStance = true
 end
 
-IdleHunt = function(actor) Trigger.OnIdle(actor, actor.Hunt) end
+IdleHunt = function(actor)
+	Trigger.OnIdle(actor, function(a)
+		if a.IsInWorld then
+			a.Hunt()
+		end
+	end)
+end
 
 Tick = function()
 	if TeleportJeepCamera and Jeep.IsInWorld then

--- a/mods/ra/maps/desert-shellmap/desert-shellmap.lua
+++ b/mods/ra/maps/desert-shellmap/desert-shellmap.lua
@@ -36,9 +36,17 @@ ParadropWaypoints = { Paradrop1, Paradrop2, Paradrop3, Paradrop4, Paradrop5, Par
 BindActorTriggers = function(a)
 	if a.HasProperty("Hunt") then
 		if a.Owner == allies then
-			Trigger.OnIdle(a, a.Hunt)
+			Trigger.OnIdle(a, function(a)
+				if a.IsInWorld then
+					a.Hunt()
+				end
+			end)
 		else
-			Trigger.OnIdle(a, function(a) a.AttackMove(AlliedTechnologyCenter.Location) end)
+			Trigger.OnIdle(a, function(a)
+				if a.IsInWorld then
+					a.AttackMove(AlliedTechnologyCenter.Location)
+				end
+			end)
 		end
 	end
 

--- a/mods/ra/maps/intervention/intervention.lua
+++ b/mods/ra/maps/intervention/intervention.lua
@@ -60,7 +60,11 @@ ParadropSovietUnits = function()
 	local units = powerproxy.SendParatroopers(MCVDeployLocation.CenterPosition, false, 256 - 53)
 
 	Utils.Do(units, function(a)
-		Trigger.OnIdle(a, a.Hunt)
+		Trigger.OnIdle(a, function(actor)
+			if actor.IsInWorld then
+				actor.Hunt()
+			end
+		end)
 	end)
 
 	powerproxy.Destroy()

--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -186,7 +186,11 @@ SendSovietParadrops = function(table)
 	local units = powerproxy.SendParatroopers(table[2].CenterPosition, false, table[1])
 
 	Utils.Do(units, function(unit)
-		Trigger.OnIdle(unit, unit.Hunt)
+		Trigger.OnIdle(unit, function(a)
+			if a.IsInWorld then
+				a.Hunt()
+			end
+		end)
 	end)
 end
 

--- a/mods/ra/maps/survival02/survival02.lua
+++ b/mods/ra/maps/survival02/survival02.lua
@@ -35,7 +35,13 @@ ParaWaves =
 	{ AttackTicks * 3, { "SovietSquad", SovietParaDrop1 } }
 }
 
-IdleHunt = function(unit) Trigger.OnIdle(unit, unit.Hunt) end
+IdleHunt = function(unit)
+	Trigger.OnIdle(unit, function(a)
+		if a.IsInWorld then
+			a.Hunt()
+		end
+	end)
+end
 
 GuardHarvester = function(unit, harvester)
 	if not unit.IsDead then


### PR DESCRIPTION
A recent PR changed ParaDrop from an Effect to an Activity. Idle triggers in the mission scripts however have already queued activities for the paradropped units, so the ParaDrop activity would only run once the first activity had finished (which could never happen).